### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/KevinZhao/dify-sdk-go
+module github.com/langgenius/dify-sdk-go
 
 go 1.16


### PR DESCRIPTION
fixbug:
 imports
        github.com/langgenius/dify-sdk-go: github.com/langgenius/dify-sdk-go@v0.0.0-20241031143354-972c4addddf6: parsing go.mod:
        module declares its path as: github.com/KevinZhao/dify-sdk-go
                but was required as: github.com/langgenius/dify-sdk-go